### PR TITLE
chore: remove unused build and preview scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The `build` and `preview` scripts were removed, simplifying the project configuration.