### PR TITLE
feat: add internet page buttons

### DIFF
--- a/src/components/InternetPage.tsx
+++ b/src/components/InternetPage.tsx
@@ -65,7 +65,6 @@ export default function InternetPage() {
           .sort((a, b) => b.networkStrength - a.networkStrength)
           .map((network) => {
             const NetworkCellIcon = NetworkCellIcons[network.networkStrength];
-
             return (
               <Button
                 key={network.key}
@@ -76,7 +75,7 @@ export default function InternetPage() {
                   textTransform: "none",
                   textAlign: "left",
                   height: "3.5rem",
-                  gap: "1rem",
+                  gap: 2.5,
                   px: 3,
                 }}
               >
@@ -102,7 +101,7 @@ export default function InternetPage() {
             justifyContent: "flex-start",
             textTransform: "none",
             height: "3.5rem",
-            gap: "1rem",
+            gap: 2.5,
             px: 3,
           }}
         >
@@ -117,9 +116,9 @@ export default function InternetPage() {
           color="inherit"
           sx={{
             justifyContent: "flex-start",
-            px: 3,
-            py: 1.75,
             textTransform: "none",
+            py: 1.75,
+            px: 3,
           }}
         >
           <Stack alignItems={"flex-start"} flex={1}>
@@ -136,9 +135,9 @@ export default function InternetPage() {
           color="inherit"
           sx={{
             justifyContent: "flex-start",
-            px: 3,
-            py: 1.75,
             textTransform: "none",
+            py: 1.75,
+            px: 3,
           }}
         >
           <Stack alignItems={"flex-start"} flex={1}>
@@ -155,9 +154,9 @@ export default function InternetPage() {
           color="inherit"
           sx={{
             justifyContent: "flex-start",
-            px: 3,
-            py: 1.75,
             textTransform: "none",
+            py: 1.75,
+            px: 3,
           }}
         >
           <Stack alignItems={"flex-start"} flex={1}>

--- a/src/components/InternetPage.tsx
+++ b/src/components/InternetPage.tsx
@@ -7,7 +7,8 @@ import NetworkWifi3BarOutlinedIcon from "@mui/icons-material/NetworkWifi3BarOutl
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import SignalWifi0BarOutlinedIcon from "@mui/icons-material/SignalWifi0BarOutlined";
 import SignalWifi4BarOutlinedIcon from "@mui/icons-material/SignalWifi4BarOutlined";
-import { Divider, IconButton, Stack, Typography } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import { Button, Divider, IconButton, Stack, Typography } from "@mui/material";
 import Page from "./page/Page";
 import { useMemo } from "react";
 
@@ -21,27 +22,32 @@ const NetworkCellIcons = {
 
 export default function InternetPage() {
   const networks = useMemo(() => {
-    return Array.from({ length: 100 }, (_, index) => {
-      const iconIndex = faker.number.int({
-        min: 0,
-        max: 4,
-      }) as keyof typeof NetworkCellIcons;
-      const IconComponent = NetworkCellIcons[iconIndex];
-      return {
-        key: index,
-        icon: <IconComponent />,
-        name: faker.internet.displayName(),
-      };
-    });
+    return Array.from(
+      { length: faker.number.int({ min: 15, max: 20 }) },
+      (_, index) => {
+        const networkStrength = faker.number.int({
+          min: 0,
+          max: 4,
+        }) as keyof typeof NetworkCellIcons;
+        return {
+          key: index,
+          networkStrength,
+          name: faker.internet.displayName(),
+          open: faker.datatype.boolean(0.75),
+        };
+      }
+    );
   }, []);
 
   return (
     <Page title="Internet">
-      <Stack gap={1} py={1}>
-        <Stack direction="row" alignItems="center" gap={2} px={2}>
-          <NetworkCellIcon />
+      <Stack py={1}>
+        <Stack direction="row" alignItems="center" gap={2} px={3} mb={1}>
+          <NetworkCellIcon sx={{ mr: 1 }} />
           <Stack flex={1}>
-            <Typography variant="subtitle1">SFR</Typography>
+            <Typography variant="h6" fontWeight={400} lineHeight={1.4}>
+              SFR
+            </Typography>
             <Typography variant="body2" color="text.secondary">
               Connected/5G
             </Typography>
@@ -51,30 +57,132 @@ export default function InternetPage() {
             <SettingsOutlinedIcon />
           </IconButton>
         </Stack>
-        <Divider variant="fullWidth" />
-        <Typography variant="h6" fontWeight={400} px={2} py={1}>
+        <Divider variant="fullWidth" sx={{ mb: 1 }} />
+        <Typography variant="h6" fontWeight={400} px={3} py={1} mb={1}>
           Wi-Fi networks
         </Typography>
-        {networks.map((network) => {
-          return (
-            <Stack
-              key={network.key}
-              direction="row"
-              alignItems="center"
-              gap={2}
-              px={2}
-              height="3rem"
-            >
-              {network.icon}
-              <Typography variant="subtitle1" flex="1">
-                {network.name}
-              </Typography>
-              <IconButton disabled>
-                <LockOutlinedIcon />
-              </IconButton>
-            </Stack>
-          );
-        })}
+        {networks
+          .sort((a, b) => b.networkStrength - a.networkStrength)
+          .map((network) => {
+            const NetworkCellIcon = NetworkCellIcons[network.networkStrength];
+
+            return (
+              <Button
+                key={network.key}
+                size="large"
+                color="inherit"
+                sx={{
+                  justifyContent: "flex-start",
+                  textTransform: "none",
+                  textAlign: "left",
+                  height: "3.5rem",
+                  gap: "1rem",
+                  px: 3,
+                }}
+              >
+                <NetworkCellIcon />
+                <Typography variant="h6" fontWeight={400} flex="1" noWrap>
+                  {network.name}
+                </Typography>
+                <Stack
+                  height={40}
+                  width={40}
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  {network.open ? <LockOutlinedIcon /> : null}
+                </Stack>
+              </Button>
+            );
+          })}
+        <Button
+          size="large"
+          color="inherit"
+          sx={{
+            justifyContent: "flex-start",
+            textTransform: "none",
+            height: "3.5rem",
+            gap: "1rem",
+            px: 3,
+          }}
+        >
+          <AddIcon />
+          <Typography variant="h6" fontWeight={400}>
+            Add network
+          </Typography>
+        </Button>
+        <Divider variant="fullWidth" />
+        <Button
+          size="large"
+          color="inherit"
+          sx={{
+            justifyContent: "flex-start",
+            px: 3,
+            py: 1.75,
+            textTransform: "none",
+          }}
+        >
+          <Stack alignItems={"flex-start"} flex={1}>
+            <Typography variant="h6" fontWeight={400} lineHeight={1.4}>
+              Network preferences
+            </Typography>
+            <Typography variant="body2" color="textSecondary" fontWeight={400}>
+              Wi-Fi turns back on automatically
+            </Typography>
+          </Stack>
+        </Button>
+        <Button
+          size="large"
+          color="inherit"
+          sx={{
+            justifyContent: "flex-start",
+            px: 3,
+            py: 1.75,
+            textTransform: "none",
+          }}
+        >
+          <Stack alignItems={"flex-start"} flex={1}>
+            <Typography variant="h6" fontWeight={400} lineHeight={1.4}>
+              Saved networks
+            </Typography>
+            <Typography variant="body2" color="textSecondary" fontWeight={400}>
+              {faker.number.int({ min: 5, max: 300 })} networks
+            </Typography>
+          </Stack>
+        </Button>
+        <Button
+          size="large"
+          color="inherit"
+          sx={{
+            justifyContent: "flex-start",
+            px: 3,
+            py: 1.75,
+            textTransform: "none",
+          }}
+        >
+          <Stack alignItems={"flex-start"} flex={1}>
+            <Typography variant="h6" fontWeight={400} lineHeight={1.4}>
+              Non-operator data usage
+            </Typography>
+            <Typography variant="body2" color="textSecondary" fontWeight={400}>
+              {faker.number.float({
+                min: 0.1,
+                max: 50,
+                fractionDigits: 2,
+              })}{" "}
+              GB used{" "}
+              {faker.date.recent({ days: 30 }).toLocaleDateString("en-GB", {
+                day: "numeric",
+                month: "short",
+              })}{" "}
+              -{" "}
+              {new Date().toLocaleDateString("en-GB", {
+                day: "numeric",
+                month: "short",
+              })}
+            </Typography>
+          </Stack>
+        </Button>
       </Stack>
     </Page>
   );

--- a/src/components/page/headers/StaticHeader.tsx
+++ b/src/components/page/headers/StaticHeader.tsx
@@ -20,7 +20,7 @@ export default function StaticHeader({
       elevation={0}
       square
       sx={{
-        paddingTop: 5,
+        paddingTop: 6,
         paddingLeft: 2,
         paddingRight: 5,
         paddingBottom: 3,

--- a/src/components/page/headers/StickyHeader.tsx
+++ b/src/components/page/headers/StickyHeader.tsx
@@ -6,6 +6,7 @@ import {
   type CSSProperties,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import RestartAltOutlinedIcon from "@mui/icons-material/RestartAltOutlined";
 import type { MotionValue } from "motion";
 import { motion, useTransform } from "motion/react";
 
@@ -50,7 +51,7 @@ export default function StickyHeader({
       <IconButton>
         <ArrowBackIcon />
       </IconButton>
-      <Typography>
+      <Typography variant="h6" fontWeight={400} flex={1}>
         <motion.span
           style={{
             opacity: visibility,
@@ -59,6 +60,9 @@ export default function StickyHeader({
           {title}
         </motion.span>
       </Typography>
+      <IconButton>
+        <RestartAltOutlinedIcon />
+      </IconButton>
     </Stack>
   );
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `InternetPage` and header components (`StaticHeader` and `StickyHeader`) to improve UI consistency, functionality, and user experience. Key changes include the addition of new buttons and icons, dynamic generation of network data, and adjustments to typography and layout styling.

### Internet Page Enhancements:

* **Dynamic Network List Generation**: The `networks` array now dynamically generates between 15-20 items, each with randomized network strength, name, and open status. Networks are displayed in descending order of signal strength. [[1]](diffhunk://#diff-c17840fcec5a37de531bcf69c2ab4027ca7d6bf88c234da8bda4926c01eca2a3L24-R50) [[2]](diffhunk://#diff-c17840fcec5a37de531bcf69c2ab4027ca7d6bf88c234da8bda4926c01eca2a3L54-R185)
* **UI Improvements**: Replaced `Stack` components with `Button` components for network items, added an "Add network" button with an `AddIcon`, and introduced additional buttons for network preferences, saved networks, and non-operator data usage. Typography and spacing adjustments were made for better readability and layout alignment.
* **Icon Imports**: Added `AddIcon` to the list of imported icons for use in the "Add network" button.

### Static Header Adjustments:

* **Padding Update**: Increased the `paddingTop` value from 5 to 6 for better spacing and alignment.

### Sticky Header Enhancements:

* **New Icon Button**: Added a `RestartAltOutlinedIcon` button next to the title for additional functionality. [[1]](diffhunk://#diff-9e6d94f3984f62c7d9d1acfcadf8677c28d02a5e0e49a52500ae36260f30a8f0R9) [[2]](diffhunk://#diff-9e6d94f3984f62c7d9d1acfcadf8677c28d02a5e0e49a52500ae36260f30a8f0R63-R65)
* **Typography Update**: Updated the title's typography to use `variant="h6"` with `fontWeight={400}` for consistent styling.