### PR TITLE
Fix internet pag spacing

### DIFF
--- a/src/components/InternetPage.tsx
+++ b/src/components/InternetPage.tsx
@@ -42,7 +42,7 @@ export default function InternetPage() {
   return (
     <Page title="Internet">
       <Stack py={1}>
-        <Stack direction="row" alignItems="center" gap={2} px={3} mb={1}>
+        <Stack direction="row" alignItems="center" gap={2} px={3} mb={1.5}>
           <NetworkCellIcon sx={{ mr: 1 }} />
           <Stack flex={1}>
             <Typography


### PR DESCRIPTION
This pull request includes a minor adjustment to the `InternetPage` component. The change modifies the `mb` (margin-bottom) property of a `Stack` element, increasing its value from `1` to `1.5` for improved spacing.